### PR TITLE
Use explicit count modifiers

### DIFF
--- a/TLA.tmbundle/Syntaxes/TLA.tmLanguage
+++ b/TLA.tmbundle/Syntaxes/TLA.tmLanguage
@@ -26,13 +26,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\={4,}</string>
+			<string>\={4}=*</string>
 			<key>name</key>
 			<string>markup.other.startbreak</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>={4,}</string>
+			<string>={4}=*</string>
 			<key>name</key>
 			<string>markup.other.endbreak</string>
 		</dict>


### PR DESCRIPTION
The construction `{1,}` in regular expressions is only supported by Oniguruma (which is used by TextMate). This TextMate bundle is used to highlight TLA code on github.com. However, github.com is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes.

This pull request fixes that by using explicit count modifiers.