### PR TITLE
add predefined identifiers

### DIFF
--- a/TLA.tmbundle/Syntaxes/TLA.tmLanguage
+++ b/TLA.tmbundle/Syntaxes/TLA.tmLanguage
@@ -42,6 +42,12 @@
 			<key>name</key>
 			<string>constant.numeric</string>
 		</dict>
+        <dict>
+            <key>match</key>
+            <string>\b(BOOLEAN|FALSE|STRING|TRUE)\b</string>
+            <key>name</key>
+            <string>constant.language.tla</string>
+        </dict>
 		<dict>
 			<key>match</key>
 			<string>\b==\b</string>


### PR DESCRIPTION
Yet another small addition: `BOOLEAN, FALSE, STRING, TRUE`. This addition is based on the TextMate syntax that linguist uses for C, specifically `constant.language.c` (https://github.com/textmate/c.tmbundle/blob/9aa365882274ca52f01722f3dbb169b9539a20ee/Syntaxes/C.plist#L78).